### PR TITLE
UI/UX improvements: modals for auth, profile editing, forgot password, and contextual confirm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Local Deployment
+package.local.json

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { CognitoUserSession } from 'amazon-cognito-identity-js'
 import { getCurrentUserSession } from '@lib/session'
-import LogoutButton from '@components/LogoutButton'
 
 export default function DashboardPage() {
   const [loading, setLoading] = useState(true)
@@ -35,7 +34,6 @@ export default function DashboardPage() {
     <main className="bg-brand-white rounded-xl shadow-md p-8 mt-10 font-body">
       <h1 className="text-2xl font-heading font-bold text-brand-indigo mb-4">Dashboard</h1>
       <p className="mb-4">{message}</p>
-      <LogoutButton />
     </main>
   )
 }

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,95 @@
+"use client"
+import { useState } from "react"
+import { forgotPassword, confirmForgotPassword } from "@lib/cognito"
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("")
+  const [code, setCode] = useState("")
+  const [newPassword, setNewPassword] = useState("")
+  const [step, setStep] = useState<"request" | "confirm">("request")
+  const [message, setMessage] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  const handleRequest = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setMessage("")
+    try {
+      await forgotPassword(email)
+      setStep("confirm")
+      setMessage("✅ Check your email for the verification code.")
+    } catch (err: any) {
+      setMessage(`❌ ${err.message}`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleConfirm = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setMessage("")
+    try {
+      await confirmForgotPassword(email, code, newPassword)
+      setMessage("✅ Password reset! You can now log in.")
+      setStep("request")
+      setEmail("")
+      setCode("")
+      setNewPassword("")
+    } catch (err: any) {
+      setMessage(`❌ ${err.message}`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <main className="bg-brand-white rounded-xl shadow-md p-8 mt-10 font-body max-w-md mx-auto">
+      <h1 className="text-2xl font-heading font-bold text-brand-indigo mb-4">Forgot Password</h1>
+      {step === "request" ? (
+        <form onSubmit={handleRequest} className="space-y-4">
+          <input
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            placeholder="Email"
+            className="w-full border border-brand-gray-light rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-indigo"
+            required
+          />
+          <button
+            type="submit"
+            className="bg-brand-indigo hover:bg-brand-gold transition-colors text-brand-white px-4 py-2 rounded-md shadow focus:outline-none focus:ring-2 focus:ring-brand-gold"
+            disabled={loading}
+          >
+            {loading ? "Sending..." : "Send Reset Code"}
+          </button>
+        </form>
+      ) : (
+        <form onSubmit={handleConfirm} className="space-y-4">
+          <input
+            value={code}
+            onChange={e => setCode(e.target.value)}
+            placeholder="Verification Code"
+            className="w-full border border-brand-gray-light rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-indigo"
+            required
+          />
+          <input
+            type="password"
+            value={newPassword}
+            onChange={e => setNewPassword(e.target.value)}
+            placeholder="New Password"
+            className="w-full border border-brand-gray-light rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-indigo"
+            required
+          />
+          <button
+            type="submit"
+            className="bg-brand-indigo hover:bg-brand-gold transition-colors text-brand-white px-4 py-2 rounded-md shadow focus:outline-none focus:ring-2 focus:ring-brand-gold"
+            disabled={loading}
+          >
+            {loading ? "Resetting..." : "Reset Password"}
+          </button>
+        </form>
+      )}
+      {message && <p className="text-sm mt-2">{message}</p>}
+    </main>
+  )
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { CognitoUserAttribute } from 'amazon-cognito-identity-js'
 import { useEffect, useState } from 'react'
 import { CognitoUserPool } from 'amazon-cognito-identity-js'
 
@@ -13,6 +14,17 @@ export default function ProfilePage() {
   const [attributes, setAttributes] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [editMode, setEditMode] = useState(false)
+  const [form, setForm] = useState({
+    given_name: '',
+    family_name: '',
+    name: '',
+    phone_number: '',
+    birthdate: '',
+    locale: '',
+  })
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState('')
 
   useEffect(() => {
     const user = userPool.getCurrentUser()
@@ -29,7 +41,19 @@ export default function ProfilePage() {
       }
       user.getUserAttributes((err: any, attrs: any[]) => {
         if (err) setError('Could not fetch attributes')
-        else setAttributes(attrs)
+        else {
+          setAttributes(attrs)
+          // Set form values from attributes
+          const attrObj = Object.fromEntries(attrs.map(attr => [attr.getName(), attr.getValue()]))
+          setForm({
+            given_name: attrObj.given_name || '',
+            family_name: attrObj.family_name || '',
+            name: attrObj.name || '',
+            phone_number: attrObj.phone_number || '',
+            birthdate: attrObj.birthdate || '',
+            locale: attrObj.locale || '',
+          })
+        }
         setLoading(false)
       })
     })
@@ -41,6 +65,8 @@ export default function ProfilePage() {
   // Only show these attributes, in this order
   const displayOrder = [
     { key: 'email', label: 'Email' },
+    { key: 'given_name', label: 'First Name' },
+    { key: 'family_name', label: 'Last Name' },
     { key: 'name', label: 'Full Name' },
     { key: 'phone_number', label: 'Phone Number' },
     { key: 'birthdate', label: 'Birthdate' },
@@ -48,19 +74,161 @@ export default function ProfilePage() {
   ]
   const attrMap = Object.fromEntries(attributes.map(attr => [attr.getName(), attr.getValue()]))
 
+  const handleEdit = () => {
+    setEditMode(true)
+    setSaveError('')
+  }
+  const handleCancel = () => {
+    setEditMode(false)
+    setSaveError('')
+    setForm({
+      given_name: attrMap.given_name || '',
+      family_name: attrMap.family_name || '',
+      name: attrMap.name || '',
+      phone_number: attrMap.phone_number || '',
+      birthdate: attrMap.birthdate || '',
+      locale: attrMap.locale || '',
+    })
+  }
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target
+    setForm(f => {
+      // If editing given_name or family_name, update name as well
+      if (name === 'given_name' || name === 'family_name') {
+        const newGiven = name === 'given_name' ? value : f.given_name
+        const newFamily = name === 'family_name' ? value : f.family_name
+        return {
+          ...f,
+          [name]: value,
+          name: `${newGiven} ${newFamily}`.trim(),
+        }
+      }
+      return { ...f, [name]: value }
+    })
+  }
+  const handleSave = async () => {
+    setSaving(true)
+    setSaveError('')
+    const user = userPool.getCurrentUser()
+    if (!user) {
+      setSaveError('Not logged in')
+      setSaving(false)
+      return
+    }
+    user.getSession((err: any, session: any) => {
+      if (err || !session) {
+        setSaveError('Session error')
+        setSaving(false)
+        return
+      }
+      const attrs = [
+        new CognitoUserAttribute({ Name: 'given_name', Value: form.given_name }),
+        new CognitoUserAttribute({ Name: 'family_name', Value: form.family_name }),
+        new CognitoUserAttribute({ Name: 'name', Value: form.name }),
+        new CognitoUserAttribute({ Name: 'phone_number', Value: form.phone_number }),
+        new CognitoUserAttribute({ Name: 'birthdate', Value: form.birthdate }),
+        new CognitoUserAttribute({ Name: 'locale', Value: form.locale }),
+      ]
+      user.updateAttributes(attrs, (err: any) => {
+        if (err) {
+          setSaveError('Could not update profile')
+        } else {
+          setEditMode(false)
+          user.getUserAttributes((err: any, attrs: any[]) => {
+            if (!err && attrs) setAttributes(attrs)
+          })
+        }
+        setSaving(false)
+      })
+    })
+  }
+
   return (
-    <main className="bg-brand-white rounded-xl shadow-md p-8 mt-10 font-body max-w-md mx-auto">
+    <main className="bg-brand-white rounded-xl shadow-md p-8 mt-10 font-body max-w-md mx-auto relative">
+      {!editMode && (
+        <button
+          className="absolute top-6 right-6 bg-brand-gold text-brand-white px-4 py-1 rounded-md shadow hover:bg-brand-indigo transition-colors font-heading font-semibold"
+          type="button"
+          aria-label="Edit Profile"
+          onClick={handleEdit}
+        >
+          Edit
+        </button>
+      )}
       <h1 className="text-2xl font-heading font-bold text-brand-indigo mb-4">Your Profile</h1>
       <ul className="space-y-2">
         {displayOrder.map(({ key, label }) =>
-          attrMap[key] ? (
-            <li key={key} className="flex justify-between border-b border-brand-gray py-2">
-              <span className="font-semibold text-brand-dark">{label}</span>
-              <span className="text-brand-indigo break-all">{attrMap[key]}</span>
-            </li>
-          ) : null
+          !editMode ? (
+            attrMap[key] ? (
+              <li key={key} className="flex justify-between border-b border-brand-gray py-2">
+                <span className="font-semibold text-brand-dark">{label}</span>
+                <span className="text-brand-indigo break-all">{attrMap[key]}</span>
+              </li>
+            ) : null
+          ) : (
+            key === 'email' ? (
+              <li key={key} className="flex justify-between border-b border-brand-gray py-2 items-center">
+                <span className="font-semibold text-brand-dark w-1/2">{label}</span>
+                <span className="text-brand-indigo break-all w-1/2 text-right">{attrMap[key]}</span>
+              </li>
+            ) : key === 'locale' ? (
+              <li key={key} className="flex justify-between border-b border-brand-gray py-2 items-center">
+                <span className="font-semibold text-brand-dark w-1/2">{label}</span>
+                <select
+                  name="locale"
+                  value={form.locale}
+                  onChange={handleChange}
+                  className="w-1/2 border border-brand-gray-light rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-indigo text-right"
+                >
+                  <option value="">Select Locale</option>
+                  <option value="en-US">English (United States)</option>
+                  <option value="en-GB">English (United Kingdom)</option>
+                  <option value="fr-FR">French (France)</option>
+                  <option value="es-ES">Spanish (Spain)</option>
+                  <option value="de-DE">German (Germany)</option>
+                  <option value="it-IT">Italian (Italy)</option>
+                  <option value="pt-PT">Portuguese (Portugal)</option>
+                  <option value="zh-CN">Chinese (Simplified)</option>
+                  <option value="ja-JP">Japanese</option>
+                  <option value="ko-KR">Korean</option>
+                </select>
+              </li>
+            ) : (
+              <li key={key} className="flex justify-between border-b border-brand-gray py-2 items-center">
+                <span className="font-semibold text-brand-dark w-1/2">{label}</span>
+                <input
+                  name={key}
+                  type={key === 'birthdate' ? 'date' : 'text'}
+                  value={form[key as keyof typeof form] || ''}
+                  onChange={handleChange}
+                  className="w-1/2 border border-brand-gray-light rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-indigo text-right"
+                />
+              </li>
+            )
+          )
         )}
       </ul>
+      {editMode && (
+        <div className="flex gap-4 mt-6 justify-end">
+          <button
+            type="button"
+            className="bg-brand-indigo text-brand-white px-4 py-2 rounded-md shadow hover:bg-brand-gold transition-colors font-heading font-semibold"
+            onClick={handleSave}
+            disabled={saving}
+          >
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+          <button
+            type="button"
+            className="bg-brand-gray-light text-brand-dark px-4 py-2 rounded-md shadow hover:bg-brand-gray transition-colors font-heading font-semibold"
+            onClick={handleCancel}
+            disabled={saving}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+      {saveError && <p className="text-red-600 text-sm mt-2">{saveError}</p>}
     </main>
   )
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { CognitoUserPool } from 'amazon-cognito-identity-js'
+
+const poolData = {
+  UserPoolId: process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID!,
+  ClientId: process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID!,
+}
+const userPool = new CognitoUserPool(poolData)
+
+export default function ProfilePage() {
+  const [attributes, setAttributes] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const user = userPool.getCurrentUser()
+    if (!user) {
+      setError('Not logged in')
+      setLoading(false)
+      return
+    }
+    user.getSession((err: any, session: any) => {
+      if (err || !session) {
+        setError('Session error')
+        setLoading(false)
+        return
+      }
+      user.getUserAttributes((err: any, attrs: any[]) => {
+        if (err) setError('Could not fetch attributes')
+        else setAttributes(attrs)
+        setLoading(false)
+      })
+    })
+  }, [])
+
+  if (loading) return <main className="bg-brand-white rounded-xl shadow-md p-8 mt-10 font-body max-w-md mx-auto"><p>Loading...</p></main>
+  if (error) return <main className="bg-brand-white rounded-xl shadow-md p-8 mt-10 font-body max-w-md mx-auto"><p className="text-red-600">{error}</p></main>
+
+  // Only show these attributes, in this order
+  const displayOrder = [
+    { key: 'email', label: 'Email' },
+    { key: 'name', label: 'Full Name' },
+    { key: 'phone_number', label: 'Phone Number' },
+    { key: 'birthdate', label: 'Birthdate' },
+    { key: 'locale', label: 'Locale' },
+  ]
+  const attrMap = Object.fromEntries(attributes.map(attr => [attr.getName(), attr.getValue()]))
+
+  return (
+    <main className="bg-brand-white rounded-xl shadow-md p-8 mt-10 font-body max-w-md mx-auto">
+      <h1 className="text-2xl font-heading font-bold text-brand-indigo mb-4">Your Profile</h1>
+      <ul className="space-y-2">
+        {displayOrder.map(({ key, label }) =>
+          attrMap[key] ? (
+            <li key={key} className="flex justify-between border-b border-brand-gray py-2">
+              <span className="font-semibold text-brand-dark">{label}</span>
+              <span className="text-brand-indigo break-all">{attrMap[key]}</span>
+            </li>
+          ) : null
+        )}
+      </ul>
+    </main>
+  )
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -5,12 +5,39 @@ import { signUpUser } from '@lib/cognito'
 export default function SignupPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [phoneNumber, setPhoneNumber] = useState('')
+  const [givenName, setGivenName] = useState('')
+  const [familyName, setFamilyName] = useState('')
+  const [birthdate, setBirthdate] = useState('')
+  const [locale, setLocale] = useState('')
   const [message, setMessage] = useState('')
+  const [errors, setErrors] = useState<{ [key: string]: string }>({})
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    const newErrors: { [key: string]: string } = {}
+    if (!email) newErrors.email = 'Email is required.'
+    if (!password) newErrors.password = 'Password is required.'
+    if (!phoneNumber) newErrors.phoneNumber = 'Phone number is required.'
+    if (!givenName) newErrors.givenName = 'First name is required.'
+    if (!familyName) newErrors.familyName = 'Last name is required.'
+    if (!birthdate) newErrors.birthdate = 'Birthdate is required.'
+    if (!locale) newErrors.locale = 'Locale is required.'
+    setErrors(newErrors)
+    if (Object.keys(newErrors).length > 0) {
+      setMessage('❌ Please fill in all required fields.')
+      return
+    }
     try {
-      await signUpUser(email, password)
+      const name = `${givenName} ${familyName}`.trim()
+      await signUpUser(email, password, {
+        phone_number: phoneNumber,
+        name,
+        given_name: givenName,
+        family_name: familyName,
+        birthdate,
+        locale,
+      })
       setMessage('✅ Check your email for a confirmation code.')
     } catch (err: any) {
       setMessage(`❌ ${err.message}`)
@@ -22,7 +49,31 @@ export default function SignupPage() {
       <h1 className="text-2xl font-heading font-bold text-brand-indigo mb-4">Sign Up</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" className="w-full border border-brand-gray-light rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-indigo" />
+        {errors.email && <p className="text-red-600 text-xs mt-1">{errors.email}</p>}
         <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" className="w-full border border-brand-gray-light rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-indigo" />
+        {errors.password && <p className="text-red-600 text-xs mt-1">{errors.password}</p>}
+        <input value={phoneNumber} onChange={e => setPhoneNumber(e.target.value)} placeholder="Phone Number (e.g. +1234567890)" className="w-full border border-brand-gray-light rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-indigo" />
+        {errors.phoneNumber && <p className="text-red-600 text-xs mt-1">{errors.phoneNumber}</p>}
+        <input value={givenName} onChange={e => setGivenName(e.target.value)} placeholder="First Name" className="w-full border border-brand-gray-light rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-indigo" />
+        {errors.givenName && <p className="text-red-600 text-xs mt-1">{errors.givenName}</p>}
+        <input value={familyName} onChange={e => setFamilyName(e.target.value)} placeholder="Last Name" className="w-full border border-brand-gray-light rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-indigo" />
+        {errors.familyName && <p className="text-red-600 text-xs mt-1">{errors.familyName}</p>}
+        <input value={birthdate} onChange={e => setBirthdate(e.target.value)} type="date" placeholder="Birthdate" className="w-full border border-brand-gray-light rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-indigo" />
+        {errors.birthdate && <p className="text-red-600 text-xs mt-1">{errors.birthdate}</p>}
+        <select value={locale} onChange={e => setLocale(e.target.value)} className="w-full border border-brand-gray-light rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-indigo">
+          <option value="">Select Locale</option>
+          <option value="en-US">English (United States)</option>
+          <option value="en-GB">English (United Kingdom)</option>
+          <option value="fr-FR">French (France)</option>
+          <option value="es-ES">Spanish (Spain)</option>
+          <option value="de-DE">German (Germany)</option>
+          <option value="it-IT">Italian (Italy)</option>
+          <option value="pt-PT">Portuguese (Portugal)</option>
+          <option value="zh-CN">Chinese (Simplified)</option>
+          <option value="ja-JP">Japanese</option>
+          <option value="ko-KR">Korean</option>
+        </select>
+        {errors.locale && <p className="text-red-600 text-xs mt-1">{errors.locale}</p>}
         <button type="submit" className="bg-brand-indigo hover:bg-brand-gold transition-colors text-brand-white px-4 py-2 rounded-md shadow focus:outline-none focus:ring-2 focus:ring-brand-gold">Sign Up</button>
       </form>
       {message && <p className="text-sm mt-2">{message}</p>}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -39,6 +39,8 @@ export default function SignupPage() {
         locale,
       })
       setMessage('✅ Check your email for a confirmation code.')
+      // Dispatch custom event to close signup and show confirm modal
+      window.dispatchEvent(new CustomEvent('show-confirm-modal', { detail: { closeSignup: true } }))
     } catch (err: any) {
       setMessage(`❌ ${err.message}`)
     }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -7,6 +7,7 @@ import LogoutButton from './LogoutButton'
 import LoginPage from '../app/login/page'
 import SignupPage from '../app/signup/page'
 import ConfirmPage from '../app/confirm/page'
+import ForgotPasswordPage from '../app/forgot-password/page'
 
 const navItems = [
 	{ href: '/', label: 'Home' },
@@ -23,6 +24,7 @@ export default function Navbar() {
 	const [showLoginModal, setShowLoginModal] = useState(false)
 	const [showSignupModal, setShowSignupModal] = useState(false)
 	const [showConfirmModal, setShowConfirmModal] = useState(false)
+	const [showForgotModal, setShowForgotModal] = useState(false)
 
 	useEffect(() => {
 		getCurrentUserSession()
@@ -111,6 +113,12 @@ export default function Navbar() {
 					<div className="bg-white rounded-xl shadow-lg p-8 min-w-[320px] max-w-sm relative">
 						<button onClick={() => setShowLoginModal(false)} className="absolute top-2 right-2 text-brand-indigo hover:text-brand-gold text-xl">×</button>
 						<LoginPage />
+						<button
+							onClick={() => { setShowLoginModal(false); setShowForgotModal(true) }}
+							className="mt-4 text-sm text-brand-indigo hover:text-brand-gold underline"
+						>
+							Forgot password?
+						</button>
 					</div>
 				</div>
 			)}
@@ -127,6 +135,14 @@ export default function Navbar() {
 					<div className="bg-white rounded-xl shadow-lg p-8 min-w-[320px] max-w-sm relative">
 						<button onClick={() => setShowConfirmModal(false)} className="absolute top-2 right-2 text-brand-indigo hover:text-brand-gold text-xl">×</button>
 						<ConfirmPage />
+					</div>
+				</div>
+			)}
+			{showForgotModal && (
+				<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+					<div className="bg-white rounded-xl shadow-lg p-8 min-w-[320px] max-w-sm relative">
+						<button onClick={() => setShowForgotModal(false)} className="absolute top-2 right-2 text-brand-indigo hover:text-brand-gold text-xl">×</button>
+						<ForgotPasswordPage />
 					</div>
 				</div>
 			)}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { getCurrentUserSession } from '@lib/session'
+import LogoutButton from './LogoutButton'
 
 const navItems = [
 	{ href: '/', label: 'Home' },
@@ -53,6 +54,11 @@ export default function Navbar() {
 					</span>
 				</Link>
 			))}
+			{isLoggedIn && (
+				<div className="flex-1 flex justify-end items-center mb-2 mr-4">
+					<LogoutButton />
+				</div>
+			)}
 		</nav>
 	)
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -10,6 +10,7 @@ const navItems = [
 	{ href: '/confirm', label: 'Confirm' },
 	{ href: '/login', label: 'Login' },
 	{ href: '/dashboard', label: 'Dashboard' },
+	{ href: '/profile', label: 'Profile' }, // Add profile link
 ]
 
 export default function Navbar() {
@@ -27,8 +28,8 @@ export default function Navbar() {
 			// Hide home, login, signup, confirm when logged in
 			return !['/', '/login', '/signup', '/confirm'].includes(item.href)
 		} else {
-			// Hide dashboard when logged out
-			return item.href !== '/dashboard'
+			// Hide dashboard and profile when logged out
+			return !['/dashboard', '/profile'].includes(item.href)
 		}
 	})
 

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,64 +1,135 @@
 'use client'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { getCurrentUserSession } from '@lib/session'
 import LogoutButton from './LogoutButton'
+import LoginPage from '../app/login/page'
+import SignupPage from '../app/signup/page'
+import ConfirmPage from '../app/confirm/page'
 
 const navItems = [
 	{ href: '/', label: 'Home' },
 	{ href: '/signup', label: 'Sign Up' },
-	{ href: '/confirm', label: 'Confirm' },
 	{ href: '/login', label: 'Login' },
 	{ href: '/dashboard', label: 'Dashboard' },
-	{ href: '/profile', label: 'Profile' }, // Add profile link
+	{ href: '/profile', label: 'Profile' },
 ]
 
 export default function Navbar() {
 	const pathname = usePathname()
+	const router = useRouter()
 	const [isLoggedIn, setIsLoggedIn] = useState(false)
+	const [showLoginModal, setShowLoginModal] = useState(false)
+	const [showSignupModal, setShowSignupModal] = useState(false)
+	const [showConfirmModal, setShowConfirmModal] = useState(false)
 
 	useEffect(() => {
 		getCurrentUserSession()
 			.then((session) => setIsLoggedIn(!!session && session.isValid && session.isValid()))
 			.catch(() => setIsLoggedIn(false))
+		// Listen for custom event to show confirm modal
+		const handler = (e: any) => {
+			if (e.detail && e.detail.closeSignup) setShowSignupModal(false)
+			setShowConfirmModal(true)
+		}
+		window.addEventListener('show-confirm-modal', handler)
+		return () => window.removeEventListener('show-confirm-modal', handler)
 	}, [])
 
 	const filteredNavItems = navItems.filter((item) => {
 		if (isLoggedIn) {
-			// Hide home, login, signup, confirm when logged in
 			return !['/', '/login', '/signup', '/confirm'].includes(item.href)
 		} else {
-			// Hide dashboard and profile when logged out
 			return !['/dashboard', '/profile'].includes(item.href)
 		}
 	})
 
+	// Separate login/signup for right alignment if on home page
+	const mainNavItems = filteredNavItems.filter(item => !['/login', '/signup'].includes(item.href))
+	const authNavItems = filteredNavItems.filter(item => ['/login', '/signup'].includes(item.href))
+
 	return (
-		<nav className="bg-brand-white/80 backdrop-blur sticky top-0 z-20 shadow-md p-lg flex items-center gap-6 border-b">
-			<Link href={isLoggedIn ? '/dashboard' : '/'}>
-				<span className="text-2xl font-heading font-bold text-brand-indigo tracking-tight mr-8">
-					Newriive
-				</span>
-			</Link>
-			{filteredNavItems.map(({ href, label }) => (
-				<Link key={href} href={href} className="relative group">
-					<span
-						className={
-							pathname === href
-								? 'text-brand-indigo font-semibold underline underline-offset-4'
-								: 'text-brand-text-dark group-hover:text-brand-gold transition-colors'
-						}
-					>
-						{label}
+		<>
+			<nav className="bg-brand-white/80 backdrop-blur sticky top-0 z-20 shadow-md p-lg flex items-center gap-6 border-b">
+				<Link href={isLoggedIn ? '/dashboard' : '/'}>
+					<span className="text-2xl font-heading font-bold text-brand-indigo tracking-tight mr-8">
+						Newriive
 					</span>
 				</Link>
-			))}
-			{isLoggedIn && (
-				<div className="flex-1 flex justify-end items-center mb-2 mr-4">
-					<LogoutButton />
+				<div className="flex gap-6 flex-grow items-center">
+					{mainNavItems.map(({ href, label }) => (
+						<Link key={href} href={href} className="relative group">
+							<span
+								className={
+									pathname === href
+										? 'text-brand-indigo font-semibold underline underline-offset-4'
+										: 'text-brand-text-dark group-hover:text-brand-gold transition-colors'
+								}
+							>
+								{label}
+							</span>
+						</Link>
+					))}
+				</div>
+				{!isLoggedIn && (
+					<div className="flex gap-4 items-center ml-auto mr-4">
+						{authNavItems.map(({ href, label }) => (
+							pathname === '/' ? (
+								<button
+									key={href}
+									onClick={() => href === '/login' ? setShowLoginModal(true) : setShowSignupModal(true)}
+									className="font-heading font-semibold text-brand-indigo hover:text-brand-gold transition-colors px-3 py-1 rounded"
+								>
+									{label}
+								</button>
+							) : (
+								<Link key={href} href={href} className="relative group">
+									<span
+										className={
+											pathname === href
+												? 'text-brand-indigo font-semibold underline underline-offset-4'
+												: 'text-brand-text-dark group-hover:text-brand-gold transition-colors'
+										}
+									>
+										{label}
+									</span>
+								</Link>
+							)
+						))}
+					</div>
+				)}
+				{isLoggedIn && (
+					<div className="flex-1 flex justify-end items-center mb-2 mr-4">
+						<LogoutButton />
+					</div>
+				)}
+			</nav>
+			{/* Modal overlays with actual forms */}
+			{showLoginModal && (
+				<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+					<div className="bg-white rounded-xl shadow-lg p-8 min-w-[320px] max-w-sm relative">
+						<button onClick={() => setShowLoginModal(false)} className="absolute top-2 right-2 text-brand-indigo hover:text-brand-gold text-xl">×</button>
+						<LoginPage />
+					</div>
 				</div>
 			)}
-		</nav>
+			{showSignupModal && (
+				<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+					<div className="bg-white rounded-xl shadow-lg p-8 min-w-[320px] max-w-sm relative">
+						<button onClick={() => setShowSignupModal(false)} className="absolute top-2 right-2 text-brand-indigo hover:text-brand-gold text-xl">×</button>
+						<SignupPage />
+					</div>
+				</div>
+			)}
+			{showConfirmModal && (
+				<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+					<div className="bg-white rounded-xl shadow-lg p-8 min-w-[320px] max-w-sm relative">
+						<button onClick={() => setShowConfirmModal(false)} className="absolute top-2 right-2 text-brand-indigo hover:text-brand-gold text-xl">×</button>
+						<ConfirmPage />
+					</div>
+				</div>
+			)}
+		</>
 	)
 }

--- a/lib/cognito.ts
+++ b/lib/cognito.ts
@@ -101,3 +101,30 @@ export function signInUser(email: string, password: string): Promise<any> {
     });
   });
 }
+
+export function forgotPassword(email: string): Promise<any> {
+  const user = new CognitoUser({
+    Username: email,
+    Pool: userPool,
+  });
+  return new Promise((resolve, reject) => {
+    user.forgotPassword({
+      onSuccess: resolve,
+      onFailure: reject,
+      inputVerificationCode: () => resolve(true),
+    });
+  });
+}
+
+export function confirmForgotPassword(email: string, code: string, newPassword: string): Promise<any> {
+  const user = new CognitoUser({
+    Username: email,
+    Pool: userPool,
+  });
+  return new Promise((resolve, reject) => {
+    user.confirmPassword(code, newPassword, {
+      onSuccess: resolve,
+      onFailure: reject,
+    });
+  });
+}

--- a/lib/cognito.ts
+++ b/lib/cognito.ts
@@ -12,10 +12,54 @@ const poolData = {
 
 const userPool = new CognitoUserPool(poolData);
 
-export function signUpUser(email: string, password: string): Promise<any> {
+export function signUpUser(
+  email: string,
+  password: string,
+  attributes: {
+    phone_number?: string;
+    name?: string;
+    given_name?: string;
+    family_name?: string;
+    birthdate?: string;
+    locale?: string;
+  } = {}
+): Promise<any> {
   const attributeList = [
     new CognitoUserAttribute({ Name: "email", Value: email }),
   ];
+  if (attributes.phone_number)
+    attributeList.push(
+      new CognitoUserAttribute({
+        Name: "phone_number",
+        Value: attributes.phone_number,
+      })
+    );
+  if (attributes.name)
+    attributeList.push(
+      new CognitoUserAttribute({ Name: "name", Value: attributes.name })
+    );
+  if (attributes.given_name)
+    attributeList.push(
+      new CognitoUserAttribute({
+        Name: "given_name",
+        Value: attributes.given_name,
+      })
+    );
+  if (attributes.family_name)
+    attributeList.push(
+      new CognitoUserAttribute({
+        Name: "family_name",
+        Value: attributes.family_name,
+      })
+    );
+  if (attributes.birthdate)
+    attributeList.push(
+      new CognitoUserAttribute({ Name: "birthdate", Value: attributes.birthdate })
+    );
+  if (attributes.locale)
+    attributeList.push(
+      new CognitoUserAttribute({ Name: "locale", Value: attributes.locale })
+    );
 
   return new Promise((resolve, reject) => {
     userPool.signUp(email, password, attributeList, [], (err, result) => {


### PR DESCRIPTION
- Added modal-based Login, Sign Up, Confirm, and Forgot Password flows on the home page
- Moved Login and Sign Up links to the right of the navbar
- Confirm modal now opens contextually after signup
- Forgot password modal and flow implemented
- Profile page supports editing all signup fields
- Logout button moved to navbar, styled and spaced
- Improved attribute label formatting and display order on profile
- Removed persistent Confirm link from navbar
- Various UI/UX and workflow improvements for a modern, session-aware experience

This PR implements all discussed authentication and profile UX improvements, and addresses navigation, modal, and session handling for a seamless user experience.